### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM debian:12-slim
+
+# Install basic build dependencies
+RUN apt-get update && apt-get install -y \
+    git build-essential ninja-build cmake curl ca-certificates pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install vcpkg
+RUN git clone https://github.com/microsoft/vcpkg /opt/vcpkg \
+    && /opt/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+ENV VCPKG_ROOT=/opt/vcpkg
+ENV PATH="$PATH:/opt/vcpkg"
+
+WORKDIR /usr/src/app
+COPY . .
+
+# Install dependencies and build the project
+RUN vcpkg install --triplet x64-linux \
+    && cmake -B build -G Ninja \
+       -DCMAKE_TOOLCHAIN_FILE=/opt/vcpkg/scripts/buildsystems/vcpkg.cmake \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DGIMUSRV_FRONTEND=STANDALONE \
+    && cmake --build build
+
+WORKDIR /usr/src/app/deploy
+EXPOSE 9960
+CMD ["../build/standalone_frontend/gimuserverw"]

--- a/README.MD
+++ b/README.MD
@@ -16,6 +16,17 @@ For more information about the strategy of the offline mod/purpose of this serve
 ## Building
 See the [Tutorial](https://decompfrontier.github.io/pages/Tutorial/index.html) pages section "Development setup" for more information.
 
+### Docker
+For a quick Linux build you can use the provided `Dockerfile`. It compiles the
+server on a Debian base image and runs the standalone frontend.
+
+```bash
+docker build -t gimuserv .
+docker run -p 9960:9960 gimuserv
+```
+
+The server will start using the configuration files from the `deploy` directory.
+
 ## Legal
 The code of this project is released under the Affero GNU Public License v3.0+.
 


### PR DESCRIPTION
## Summary
- add a Dockerfile for building the server on Debian
- document Docker build and run instructions in README

## Testing
- `cmake -S . -B build -G Ninja -DGIMUSRV_FRONTEND=STANDALONE` *(fails: Could not find cryptoppConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_6866979c5ad08323968a6615da03fb13