### PR TITLE
Add public hostname setting

### DIFF
--- a/deploy/gimuconfig.json
+++ b/deploy/gimuconfig.json
@@ -8,7 +8,8 @@
   "server": {
     "wallpaper_banner": "/wallpaper/title_logo20151028.jpg",
     "game_version": 21900,
-    "notice_url": "http://ios21900.bfww.gumi.sg/pages/versioninfo"
+    "notice_url": "http://ios21900.bfww.gumi.sg/pages/versioninfo",
+    "public_hostname": "127.0.0.1:9960"
   },
 	"log":
 	{

--- a/gimuserver/core/Utils.cpp
+++ b/gimuserver/core/Utils.cpp
@@ -32,7 +32,10 @@ void Utils::DumpInfoToDrogon(const drogon::HttpRequestPtr& rq, const std::string
 
 std::string Utils::GetDrogonBindHostname()
 {
-	return app().getListeners()[0].toIpPort();
+        const auto& publicHost = System::Instance().ServerConfig().PublicHostname;
+        if (!publicHost.empty())
+                return publicHost;
+        return app().getListeners()[0].toIpPort();
 }
 
 std::string Utils::GetDrogonHttpBindHostname()

--- a/gimuserver/system/ServerConfig.cpp
+++ b/gimuserver/system/ServerConfig.cpp
@@ -2,8 +2,10 @@
 
 void ServerConfig::ParseFromJson(const Json::Value& v)
 {
-	Wallpaper = v["wallpaper_banner"].asString();
-	GameVersion = v["game_version"].asInt();
-	NoticeUrl = v["notice_url"].asString();
+        Wallpaper = v["wallpaper_banner"].asString();
+        GameVersion = v["game_version"].asInt();
+        NoticeUrl = v["notice_url"].asString();
+        if (v.isMember("public_hostname"))
+                PublicHostname = v["public_hostname"].asString();
 }
 

--- a/gimuserver/system/ServerConfig.hpp
+++ b/gimuserver/system/ServerConfig.hpp
@@ -4,11 +4,12 @@
 
 struct ServerConfig
 {
-	explicit ServerConfig() : GameVersion(0) {}
+        explicit ServerConfig() : GameVersion(0) {}
 
 	std::string Wallpaper;
 	int GameVersion;
-	std::string NoticeUrl;
+        std::string NoticeUrl;
+        std::string PublicHostname;
 
 	void ParseFromJson(const Json::Value& v);
 };


### PR DESCRIPTION
## Summary
- allow configuring a `public_hostname` in `gimuconfig.json`
- parse the new option and use it when returning the server address

## Testing
- `cmake -S . -B build -DGIMUSRV_FRONTEND=STANDALONE` *(fails: Could not find cryptopp)*

------
https://chatgpt.com/codex/tasks/task_e_6866f31713748323b794de152f2fdc2f